### PR TITLE
igFileDescriptor added to new directories!!

### DIFF
--- a/igCauldron3/Frames/DirectoryCreatorFrame.cs
+++ b/igCauldron3/Frames/DirectoryCreatorFrame.cs
@@ -34,8 +34,10 @@ namespace igCauldron3
 			newDir._nameList = new igNameList();
 			newDir._useNameList = true;
 			newDir._type = igObjectDirectory.FileType.kIGZ;
+			newDir._fd = new igFileDescriptor();
+			newDir._fd._device = igFileContext.Singleton._archiveManager._patchArchives[0];
 
-			igObjectStreamManager.Singleton.AddObjectDirectory(newDir, _path);
+            igObjectStreamManager.Singleton.AddObjectDirectory(newDir, _path);
 
 			DirectoryManagerFrame._instance.AddDirectory(newDir);
 


### PR DESCRIPTION
populated the _fd field on a new igObjectDirectory, and set the _device to patchArchive[0]
should fix creating new IGZ files on SuperChargers and Imaginators.